### PR TITLE
Change PhD to Diploma thesis

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -78,9 +78,10 @@
   pages =        "424--437",
 }
 
-@phdthesis{pohlmann2011,
+@mastersthesis{pohlmann2011,
   title =        {Configurable graph drawing algorithms for the {TikZ} graphics
                   description language},
+  type =         {Diploma thesis},
   author =       {Pohlmann, Jannis},
   year =         2011,
   school =       {Institute of Theoretical Computer Science, Universit{\"a}t zu


### PR DESCRIPTION
Jannis (that's me) never wrote a PhD thesis. "Configurable graph
drawing algorithms for the TikZ graphics description language" is
a diploma/graduate thesis, the old-school German equivalent to
an MSc.