### PR TITLE
Fix typo: semverg -> semver

### DIFF
--- a/tikz-feynman.tex
+++ b/tikz-feynman.tex
@@ -450,7 +450,7 @@ and feature requests is done at
 \href{https://github.com/JP-Ellis/tikz-feynman}{Github}\footnote{\url{https://github.com/JP-Ellis/tikz-feynman}}.
 
 \tikzfeynmanname{}'s versioning will approximately follow
-\href{http://semverg.org}{semantic versioning}.  This means that changes in the
+\href{http://semver.org}{semantic versioning}.  This means that changes in the
 third number (|1.0.0| to |1.0.1|) will consist of bug fixes and very minor
 changes but they should not change the output otherwise\footnote{That is, with
   the exception of the bug that they are fixing.}.  Changes in the second number


### PR DESCRIPTION
Fixed typo of semantic versioning website.
http://semverg.org -> http://semver.org