### PR TITLE
add spaces in package info

### DIFF
--- a/tikz-feynman.sty
+++ b/tikz-feynman.sty
@@ -22,7 +22,7 @@
 \def\tikzfeynman@version@patch{0}
 \edef\tikzfeynman@version{\tikzfeynman@version@major.\tikzfeynman@version@minor.\tikzfeynman@version@patch}
 
-\ProvidesPackage{tikz-feynman}[\tikzfeynman@date v\tikzfeynman@version Feynman diagrams with TikZ]
+\ProvidesPackage{tikz-feynman}[\tikzfeynman@date\space v\tikzfeynman@version\space Feynman diagrams with TikZ]
 
 \RequirePackage{tikz}[2013/12/13] % v3.0.0
 \RequirePackage{ifluatex}


### PR DESCRIPTION
This commit adds spaces between parts of the package information written into `.log` file, if a `\listfiles` command is used in `.tex` file.

 - Before: `tikz-feynman.sty    2016/02/05v1.1.0Feynman diagrams with TikZ`
 - After: `tikz-feynman.sty    2016/02/05 v1.1.0 Feynman diagrams with TikZ`